### PR TITLE
Update GitHub actions versions + Codeception/WP Browser fixes

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -7,39 +7,39 @@ WP_VERSION=latest
 
 # This is where, in the context of the CI, we'll install and configure WordPress.
 # See `.travis.yml` for more information.
-WP_ROOT_FOLDER=/tmp/wordpress
+WP_ROOT_FOLDER=/var/www/html
 
 # The WordPress installation will be served from the Docker container.
 # See `dev/docker/ci-compose.yml` for more information.
-WP_URL=http://localhost:8080
-WP_DOMAIN=localhost:8080
+WP_URL=http://wordpress.test
+WP_DOMAIN=wordpress.test
 
 # The credentials that will be used to access the site in acceptance tests
 # in methods like `$I->loginAsAdmin();`.
 WP_ADMIN_USERNAME=admin
 WP_ADMIN_PASSWORD=password
 
-WP_DB_PORT=4306
+WP_DB_PORT=3306
 
 # The databse is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
 WP_TABLE_PREFIX=wp_
-WP_DB_HOST=127.0.0.1:4306
-WP_DB_NAME=wordpress
+WP_DB_HOST=db
+WP_DB_NAME=test
 WP_DB_USER=root
-WP_DB_PASSWORD=
+WP_DB_PASSWORD=password
 
 # The test databse is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
-WP_TEST_DB_HOST=127.0.0.1:4306
+WP_TEST_DB_HOST=db
 WP_TEST_DB_NAME=test
 WP_TEST_DB_USER=root
-WP_TEST_DB_PASSWORD=
+WP_TEST_DB_PASSWORD=password
 
 # We're using Selenium and Chrome for acceptance testing.
 # In CI context we're starting a Docker container to handle that.
 # See the `dev/docker/ci-compose.yml` file.
-CHROMEDRIVER_HOST=localhost
+CHROMEDRIVER_HOST=chrome
 CHROMEDRIVER_PORT=4444
 
 # The URL of the WordPress installation from the point of view of the Chromedriver container.
@@ -48,7 +48,7 @@ CHROMEDRIVER_PORT=4444
 # lines that, in the `wp-config.php` file, will make it so that WordPress will use as its home
 # URL whatever URL we reach it with.
 # See the `dev/docker/wp-config.php` template for more information.
-WP_CHROMEDRIVER_URL="wp.test"
+WP_CHROMEDRIVER_URL=http://wordpress.test
 
 # To run the tests let's force the background-processing lib to run in synchronous (single PHP thread) mode.
 TRIBE_NO_ASYNC=1

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
 
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           composer-options: "--ignore-platform-reqs --optimize-autoloader"
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
           extensions: mbstring, intl
           coverage: none
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           composer-options: "--ignore-platform-reqs --optimize-autoloader"
       - name: Run PHPStan static analysis

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -20,7 +20,7 @@ jobs:
     name: "Tests: WP ${{ matrix.wordpress }} / PHP ${{ matrix.php }}"
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -6,6 +6,7 @@ coverage:
 paths:
     tests: tests
     log: tests/_output
+    output: tests/_output
     data: tests/_data
     helpers: tests/_support
     wp_root: "%WP_ROOT_FOLDER%"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "stellarwp/arrays": "^1.2.1"
   },
   "require-dev": {
-    "lucatume/wp-browser": "^3.2.3",
+    "lucatume/wp-browser": ">=3.2.3 < 3.5.1",
     "szepeviktor/phpstan-wordpress": "^1.1",
     "symfony/event-dispatcher-contracts": "^2.5.1",
     "symfony/string": "^5.4",

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
### Main Changes

Removes these warnings:

![image](https://github.com/stellarwp/templates/assets/1066195/d92fb9d4-997c-4e33-acf3-595aeb12fa33)
[source](https://github.com/stellarwp/templates/actions/runs/8177078398)


### Other Changes
- https://github.com/lucatume/wp-browser/releases/tag/3.5.1 Seems bugged for this project, so I limited the version in composer.json
- Codeception was complaining about not having an output directory configured.
- Tests were also failing due to not being able to connect the database, it seems `.env.testing` is taking over slic, so I updated that to match.